### PR TITLE
Rewrite charter to new wg-layer2 scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,31 @@
-# Hydra working group
+# Layer 2 working group
 
-Welcome to the documentation repository of the Hydra working group. It holds defining documents like the working group charter and procedural documentation like meeting notes.
+Welcome to the documentation repository of the Layer 2 working group. It holds defining documents like the working group charter and procedural documentation like meeting notes.
 
 > [!NOTE]
-> The working group is currently being formed and a [dedicated git repository](https://github.com/cardano-scaling/wg-hydra) was chosen to form charter and processes. Perspectively individual documents may be moved / integrated to [intersect](https://docs.intersectmbo.org/) or its [working group index](https://intersect.gitbook.io/intersect-working-groups) as the working group gets registered.
+> This was the "Hydra" working group before and we expanded the scope in June 2025. While we had often had conversations across various layer 2 projects, agenda items and meeting notes if not otherwise mentioned were about Hydra.
 
 ## Charter
 
 > [!IMPORTANT]
-> The charter itself is in draft status and one of the first work items of the working group will be to ratify it.
+> The charter was updated when we moved the changed scope of the working group.
 
 ### Why
 
 > Why is this working group needed?
 
-- Open discussion and governance of the [hydra](https://github.com/input-output-hk/hydra) project roadmap
-- Identify and scope _fundable features_ and projects related to Hydra into a roadmap to be ratified by the community (e.g. through intersect)
 - Break up silos and cross-pollinate projects across the broader domain of scaling Cardano transaction processing
+- Identify and scope _fundable features_ and projects related to Layer 2 technology to be ratified by the community (e.g. through intersect)
+- Open discussion and governance of the [hydra](https://github.com/cardano-scaling/hydra) project roadmap
 
 ### What
 
 > What are we doing concretely?
 
-- Prioritize and scope out [💬 features](https://github.com/input-output-hk/hydra/issues?q=is%3Aissue+is%3Aopen+label%3A%22%3Aspeech_balloon%3A+feature%22) from [💭 feature ideas](https://github.com/input-output-hk/hydra/issues?q=is%3Aissue+is%3Aopen+label%3A%22%3Athought_balloon%3A+idea%22) and [💡 idea discussions](https://github.com/input-output-hk/hydra/discussions/categories/ideas).
-- Create and maintain a high-level backlog of _fundable features and projects/RFPs_ (level of detail to be defined)
-- Coordinate ratification by the community through Intersect
-- Review and report on individual project deliveries
+- Share progress and gather feedback on individual project deliveries
+- Discuss standards and [Cardano Improvement Proposals (CIPs)](https://github.com/cardano-foundation/CIPs) related to layer 2
+- Prioritize and get feedback for individual project features (e.g. [Hydra features](https://github.com/cardano-scaling/hydra/issues?q=is%3Aissue%20state%3Aopen%20type%3AFeature))
+- Chat about new layer 2 catalyst proposals and long term layer 2 projects, for example Midgard, zkFold, subbit, Cardano Lightning, μgraph, ...
 
 ### How
 
@@ -36,14 +36,17 @@ Welcome to the documentation repository of the Hydra working group. It holds def
 - The repository will hold any artifacts produced, unless more suitable places are available.
 
 #### Work group meetings
-- Bi-weekly using Google Meet, [Wednesday 14:00 UTC](https://meet.google.com/vnz-chhb-qxz)
+- Bi-weekly using Google Meet, [Wednesday 12:00 UTC](https://meet.google.com/vnz-chhb-qxz)
 - Subscribe and join using [lu.ma calendar](https://lu.ma/cardano-scaling)
 
 #### Collaboration channels
-- [`#wg-hydra`](https://discord.com/channels/1136727663583698984/1260242964513558548) on Intersect Discord [Invite link](https://discord.gg/cgesQH7xXC)
+- [`#wg-layer2`](https://discord.com/channels/1136727663583698984/1260242964513558548) on Intersect Discord [Invite link](https://discord.gg/cgesQH7xXC)
 - [`#ask-hydra`](https://discord.com/channels/826816523368005654/890903732462710836) on IOG Discord [Invite link](https://discord.com/invite/Qq5vNTg9PT)
 
 #### How membership is governed
+> [!WARNING]
+> This has proven to be a bit of an overkill given the working group is not conducting many votes. Hence this process is under review.
+
 - Signal interest by [opening an issue](https://github.com/cardano-scaling/wg-hydra/issues/new?template=sign_me_up.yml) and/or join a work group meeting
 - You are a member as long as you join regularly the work group meetings
 - New members will gain voting rights in the meeting following the one they joined
@@ -51,7 +54,7 @@ Welcome to the documentation repository of the Hydra working group. It holds def
 - Member list is kept in this charter
 
 #### Members
-See also @wg-hydra github team, in no particular order:
+See also @wg-layer2 github team, in no particular order:
 - [Sebastian Nagel](https://github.com/ch1bo) <!-- sebastian.nagel@ncoding.at -->
 - [George Flerovsky](https://github.com/GeorgeFlerovsky) (missed 3) <!-- george.flerovsky@gmail.com -->
 - [Sasha Bogicevic](https://github.com/v0d1ch) <!-- sasha.bogicevic@iohk.io -->
@@ -68,28 +71,7 @@ See also @wg-hydra github team, in no particular order:
 - Sandip Pandey <!-- sandip@sireto.com -->
 - [Perry Wasserbauer](https://github.com/Pdest08) <!-- perry.wasserbauer@gmail.com -->
 - Aaron Boyle <!-- aaron.boyle@intersectmbo.org -->
-
-#### How voting will be conducted
-- TBD
   
 > [!TIP]
 > If you read this far you might want to join us? Signal interest on above's collaboration channels by dropping a message [on Discord](https://discord.com/invite/Qq5vNTg9PT), [on Twitter](https://x.com/ch1bo_), or by [opening an issue](https://github.com/cardano-scaling/wg-hydra/issues/new?template=sign_me_up.yml)!
-
-## Agenda
-
-> [!WARNING]
-> This is very preliminary and more a tool to define scope & purpose of the working group itself. That being said, it should also provoke thought and ideally spark interest in being part of these discussions. [Open an issue ](https://github.com/cardano-scaling/wg-hydra/issues/new/choose) or a PR and we'll get you covered & involved on this journey.
-
-List of current and past topics to be discussed by the Hydra working group:
-
-  - [x] Charter of the working group
-  - [x] What to release as Hydra Head V1?
-  - [x] Whether and scope of audit Head V1? RFP?
-  - [ ] How to discover off-chain funds and standardize access to them? CIP?
-  - [ ] Ways to achieve interoperability across L2 ledgers?
-  - [ ] What features / projects to fund next?
-    - Hydra Tail as collateralized optimistic rollup or as zk rollup
-    - Payment focused projects (revisiting hydra-pay, or from Catalyst: subbit, Cardano Lightning, μgraph, Cosmex, ...)
-    - Sidechain-like variants (from Catalyst: Gummiworm, Midgard, ...)
-
 


### PR DESCRIPTION
New scope due to migration from `wg-hydra` to `wg-layer2`. To be discussed in next working group session.